### PR TITLE
Fix class_editprofile unit test error

### DIFF
--- a/unittests/classes/class_editprofile.php
+++ b/unittests/classes/class_editprofile.php
@@ -7,7 +7,7 @@ class EditProfile
  	        
  	    } 
  		 
- 		public function editProfile($userName, $address, $phoneNumber) 
+ 		public function editProfile($inputName, $address, $phoneNumber) 
  		{ 
  			 
  			$serverName = 'localhost'; 
@@ -16,11 +16,11 @@ class EditProfile
  			$passWord = ''; 
   
  			$db = new PDO("mysql:host=$serverName;port=3306;dbname=soen341;charset=utf8", "$userName", "$passWord", array(PDO::ATTR_EMULATE_PREPARES => false, PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION)); 
- 			$log = $db->query("SELECT * FROM `user` WHERE `UserName` = '$userName'"); 
+ 			$log = $db->query("SELECT * FROM `user` WHERE `UserName` = '$inputName'"); 
 			$profile = $log->fetch(\PDO::FETCH_ASSOC); 
  			
  			 
- 			if ($userName == $profile ['UserName'] && $address == $profile['Address'] && $phoneNumber == $profile ['PhoneNumber']) 
+ 			if ($inputName == $profile ['UserName'] && $address == $profile['Address'] && $phoneNumber == $profile ['PhoneNumber']) 
  				return true; 
  			else 
 				return false; 


### PR DESCRIPTION
Change the parameter name from "userName" to "inputName". It should fix the error of editprofile unit test. Please approve to check if it works.